### PR TITLE
Create UI of DictionaryDialog in Qt Designer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ tools/
 profile/
 meta.json
 
-src/*/gui/forms/anki*
+src/*/gui/forms/
 src/*/gui/resources/anki*
 
 __pycache__/

--- a/designer/dictionary_dialog.ui
+++ b/designer/dictionary_dialog.ui
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>DictionaryDialog</class>
+ <widget class="QDialog" name="DictionaryDialog">
+  <property name="windowModality">
+   <enum>Qt::WindowModal</enum>
+  </property>
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>460</width>
+    <height>251</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dictionaries</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QListWidget" name="list">
+     <property name="alternatingRowColors">
+      <bool>true</bool>
+     </property>
+     <property name="selectionMode">
+      <enum>QAbstractItemView::ExtendedSelection</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="control_box">
+     <item>
+      <widget class="QPushButton" name="bws_btn">
+       <property name="text">
+        <string>Browse</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="custom_words_btn">
+       <property name="text">
+        <string>Custom Dictionary</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="en_btn">
+       <property name="text">
+        <string>Enable</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="dis_btn">
+       <property name="text">
+        <string>Disable</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/spell_checker/dict.py
+++ b/src/spell_checker/dict.py
@@ -14,6 +14,7 @@ from aqt.utils import openFolder, showInfo, tooltip
 from .const import *
 from .bdicwriter import create_bdic
 from .anking_menu import get_anking_menu
+from .gui import dictionary_dialog
 
 
 def open_dict_dir() -> None:
@@ -47,7 +48,7 @@ class DictionaryManager:
 
         profile.setSpellCheckEnabled(False)
         profile.setSpellCheckLanguages({})
-        self._dicts = DictionaryDialog().getDictionaries()
+        self._dicts = dictionary_dialog.DictionaryDialog(parent=mw).getDictionaries()
 
         profile.setSpellCheckEnabled(profile.isSpellCheckEnabled())
         profile.setSpellCheckLanguages(self._dicts)
@@ -55,97 +56,6 @@ class DictionaryManager:
 
     def getDictionaries(self):
         return self._dicts
-
-
-class DictionaryDialog(QDialog):
-    def __init__(self):
-        QDialog.__init__(self)
-        self._setupDialog()
-        self._update()
-        self.exec()
-
-    def getDictionaries(self):
-        return self._dict
-
-    def _setupDialog(self):
-        self.setWindowTitle("Dictionaries")
-        self.setWindowModality(Qt.WindowModality.WindowModal)
-        self.resize(250, 250)
-
-        layout = QVBoxLayout()
-        self.list = QListWidget()
-        self.list.setAlternatingRowColors(True)
-        self.list.setSelectionMode(QAbstractItemView.SelectionMode.ExtendedSelection)
-        self.list.itemDoubleClicked.connect(self._toggle)
-
-        bws_btn = QPushButton("Browse")
-        bws_btn.clicked.connect(open_dict_dir)
-        custom_words_btn = QPushButton("Custom Dictionary")
-        custom_words_btn.clicked.connect(lambda _: CustomDicDialog(parent=self).exec())
-        en_btn = QPushButton("Enable")
-        en_btn.clicked.connect(self._enable)
-        dis_btn = QPushButton("Disable")
-        dis_btn.clicked.connect(self._disable)
-
-        control_box = QHBoxLayout()
-        control_box.addWidget(bws_btn)
-        control_box.addWidget(custom_words_btn)
-        control_box.addWidget(en_btn)
-        control_box.addWidget(dis_btn)
-
-        layout.addWidget(self.list)
-        layout.addLayout(control_box)
-        self.setLayout(layout)
-
-    def _update(self):
-        self._dict = []
-        self.list.clear()
-
-        try:
-            DICT_FILES = os.listdir(DICT_DIR)
-        except FileNotFoundError:
-            showInfo("Missing or no read/write permission to dictionary folder.")
-            return
-
-        for d in DICT_FILES:
-            if RE_DICT_EXT_ENABLED.search(d):
-                item = QListWidgetItem(d)
-                item.setData(Qt.ItemDataRole.UserRole, d)
-                self.list.addItem(item)
-                self._dict.append(d[:-5])
-
-        for d in DICT_FILES:
-            if RE_DICT_EXT_DISABLED.search(d):
-                item = QListWidgetItem(d)
-                item.setData(Qt.ItemDataRole.UserRole, d)
-                self.list.addItem(item)
-
-    def _enable(self):
-        sel = [i for i in range(self.list.count()) if self.list.item(i).isSelected()]
-        if sel:
-            for i in sel:
-                fn = self.list.item(i).text()
-                if RE_DICT_EXT_DISABLED.search(fn):
-                    f = os.path.join(DICT_DIR, fn)
-                    os.rename(f, f[:-9])
-        self._update()
-
-    def _disable(self):
-        sel = [i for i in range(self.list.count()) if self.list.item(i).isSelected()]
-        if sel:
-            for i in sel:
-                fn = self.list.item(i).text()
-                if RE_DICT_EXT_ENABLED.search(fn):
-                    f = os.path.join(DICT_DIR, fn)
-                    os.rename(f, f + ".disabled")
-        self._update()
-
-    def _toggle(self):
-        fn = self.list.currentItem().text()
-        if RE_DICT_EXT_ENABLED.search(fn):
-            self._disable()
-        else:
-            self._enable()
 
 
 class CustomDicDialog(QDialog):

--- a/src/spell_checker/gui/dictionary_dialog.py
+++ b/src/spell_checker/gui/dictionary_dialog.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+
+import os
+
+from aqt.qt import *
+
+from ..const import DICT_DIR, RE_DICT_EXT_DISABLED, RE_DICT_EXT_ENABLED
+
+from .forms import dictionary_dialog
+
+
+class DictionaryDialog(QDialog):
+    def __init__(self, parent):
+        super(DictionaryDialog, self).__init__(parent=parent)
+        self.form = dictionary_dialog.Ui_DictionaryDialog()
+        self.form.setupUi(self)
+        self._connect_signals()
+        self._update()
+
+    def _connect_signals(self):
+        from ..dict import CustomDicDialog, open_dict_dir
+
+        self.form.list.itemDoubleClicked.connect(self._toggle)
+        self.form.bws_btn.clicked.connect(open_dict_dir)
+        self.form.custom_words_btn.clicked.connect(
+            lambda _: CustomDicDialog(parent=self).exec()
+        )
+        self.form.en_btn.clicked.connect(self._enable)
+        self.form.dis_btn.clicked.connect(self._disable)
+
+    def getDictionaries(self):
+        self.exec()
+        return self._dict
+
+    def _update(self):
+        self._dict = []
+        self.form.list.clear()
+
+        try:
+            DICT_FILES = os.listdir(DICT_DIR)
+        except FileNotFoundError:
+            showInfo("Missing or no read/write permission to dictionary folder.")
+            return
+
+        for d in DICT_FILES:
+            if RE_DICT_EXT_ENABLED.search(d):
+                item = QListWidgetItem(d)
+                item.setData(Qt.ItemDataRole.UserRole, d)
+                self.form.list.addItem(item)
+                self._dict.append(d[:-5])
+
+        for d in DICT_FILES:
+            if RE_DICT_EXT_DISABLED.search(d):
+                item = QListWidgetItem(d)
+                item.setData(Qt.ItemDataRole.UserRole, d)
+                self.form.list.addItem(item)
+
+    def _enable(self):
+        sel = [
+            i
+            for i in range(self.form.list.count())
+            if self.form.list.item(i).isSelected()
+        ]
+        if sel:
+            for i in sel:
+                fn = self.form.list.item(i).text()
+                if RE_DICT_EXT_DISABLED.search(fn):
+                    f = os.path.join(DICT_DIR, fn)
+                    os.rename(f, f[:-9])
+        self._update()
+
+    def _disable(self):
+        sel = [
+            i
+            for i in range(self.form.list.count())
+            if self.form.list.item(i).isSelected()
+        ]
+        if sel:
+            for i in sel:
+                fn = self.form.list.item(i).text()
+                if RE_DICT_EXT_ENABLED.search(fn):
+                    f = os.path.join(DICT_DIR, fn)
+                    os.rename(f, f + ".disabled")
+        self._update()
+
+    def _toggle(self):
+        fn = self.form.list.currentItem().text()
+        if RE_DICT_EXT_ENABLED.search(fn):
+            self._disable()
+        else:
+            self._enable()


### PR DESCRIPTION
The python code for the UI is built by aab (using pyuic6) and stored in `src/spell_checker/gui/forms/qt6`. It is not tracked in the git repo, because it is a build output based on `designer/dictionary_dialog.ui`, which in turn is tracked.

The file `src/spell_checker/gui/dictionary_dialog.py` however is manually created and contains the logic connecting the UI elements with the rest of the add-ons functionality. It contains the `DictionaryDialog` class (previously in the `dict.py` file) minus the code describing the UI.

Keeping those two parts of the code in seperate files results in cleaner diffs and the use of the Qt Designer simplifies UI modifications.
The `CustomDicDialog` should of course also be handled like that, but I wanted to see if you are open to the change first.